### PR TITLE
Fix error and warning count in MegaLinter summary

### DIFF
--- a/mega-linter-plugin-dclint/dclint.megalinter-descriptor.yml
+++ b/mega-linter-plugin-dclint/dclint.megalinter-descriptor.yml
@@ -20,8 +20,10 @@ linters:
     cli_help_arg_name: "--help"
     cli_version_arg_name: "--version"
     cli_lint_fix_arg_name: "--fix"
+    cli_lint_errors_count: regex_number
     cli_lint_errors_regex: "[^0-9]*[0-9]+\\s*problems?\\s*\\(([0-9]*)\\s*errors?\\s*,\\s*[0-9]*\\s*warnings?\\)"
-    cli_lint_warnings_regex: "[^0-9]*[0-9]+\\s*problems?\\s*[0-9]*\\s*errors?\\s*,\\s*([0-9]*)\\s*warnings?\\)"
+    cli_lint_warnings_count: regex_number
+    cli_lint_warnings_regex: "[^0-9]*[0-9]+\\s*problems?\\s*\\([0-9]*\\s*errors?\\s*,\\s*([0-9]*)\\s*warnings?\\)"
     cli_lint_mode: "list_of_files"
     linter_rules_url: "https://github.com/zavoloklom/docker-compose-linter/blob/main/docs/rules.md"
     linter_rules_inline_disable_url: "https://github.com/zavoloklom/docker-compose-linter/blob/main/docs/configuration-comments.md#disabling-rules"


### PR DESCRIPTION
This will fix the summary error and warning counts reported by MegaLinter.  Before this change DCLint would always report 1 error regardless of the actual error count.

**Before**:

❌ Linted [DOCKERFILE] files with [dclint]: Found 1 error(s) and 0 warning(s) - (2.7s) (expand for details)

**After**:

❌ Linted [DOCKERFILE] files with [dclint]: Found 8 error(s) and 47 warning(s) - (2.91s) (expand for details)

| **SUMMARY**   |        |               |       |       |        |          |              |
| ------------- | ------ | ------------- | ----- | ----- | ------ | -------- | ------------ |
| Descriptor    | Linter | Mode          | Files | Fixed | Errors | Warnings | Elapsed time |
| ❌ DOCKERFILE | dclint | list_of_files | 16    |       | 1      | 0        | 2.7s         |
