### PR TITLE
Fix version extract regex

### DIFF
--- a/mega-linter-plugin-dclint/dclint.megalinter-descriptor.yml
+++ b/mega-linter-plugin-dclint/dclint.megalinter-descriptor.yml
@@ -26,7 +26,7 @@ linters:
     linter_rules_url: "https://github.com/zavoloklom/docker-compose-linter/blob/main/docs/rules.md"
     linter_rules_inline_disable_url: "https://github.com/zavoloklom/docker-compose-linter/blob/main/docs/configuration-comments.md#disabling-rules"
     linter_icon_png_url: "https://raw.githubusercontent.com/oxsecurity/megalinter/main/docs/assets/icons/dockerfile.ico"
-    version_extract_regex: '\\d*'
+    version_extract_regex: '\d+(\.\d+)+'
     examples:
       - "dclint docker-compose.yml"
       - "dclint --config .dclintrc ."


### PR DESCRIPTION
This removes MegaLinter log output, `Unable to extract version with regex re.compile('\\\\d*') from 3.1.0`.

The regex is needed parse the semantic version.  Since DCLint's version command already returns the semantic version, omitting `version_extract_regex` parameter could also resolve this issue.